### PR TITLE
fix SNBT file not reading/writing in UTF-8 causing issues in Non-ASCII characters

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
+++ b/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
@@ -223,7 +223,7 @@ public class SNBT
 			}
 		}
 
-		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file),StandardCharsets.UTF_8)))
+		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file), StandardCharsets.UTF_8)))
 		{
 			SNBTBuilder builder = new SNBTBuilder();
 			append(builder, out);

--- a/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
+++ b/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.InputStreamReader;
 import java.io.FileOutputStream;
 import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -114,7 +115,7 @@ public class SNBT
 
 		StringBuilder s = new StringBuilder();
 
-		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8")))
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8)))
 		{
 			String line;
 
@@ -222,7 +223,7 @@ public class SNBT
 			}
 		}
 
-		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8")))
+		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file),StandardCharsets.UTF_8)))
 		{
 			SNBTBuilder builder = new SNBTBuilder();
 			append(builder, out);

--- a/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
+++ b/src/main/java/com/feed_the_beast/ftbquests/util/SNBT.java
@@ -22,8 +22,10 @@ import javax.annotation.Nullable;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
-import java.io.FileReader;
-import java.io.FileWriter;
+import java.io.FileInputStream;
+import java.io.InputStreamReader;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -112,7 +114,7 @@ public class SNBT
 
 		StringBuilder s = new StringBuilder();
 
-		try (BufferedReader reader = new BufferedReader(new FileReader(file)))
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), "UTF-8")))
 		{
 			String line;
 
@@ -220,7 +222,7 @@ public class SNBT
 			}
 		}
 
-		try (PrintWriter writer = new PrintWriter(new BufferedWriter(new FileWriter(file))))
+		try (PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(file),"UTF-8")))
 		{
 			SNBTBuilder builder = new SNBTBuilder();
 			append(builder, out);


### PR DESCRIPTION
If no charset is designated, Java will use system default charset to decoding text files. System default charset may vary with different system or location, which may cause issues in decoding Non-ASCII characters. 
Here are some screenshots in FTB Interactions:
![issue1](https://user-images.githubusercontent.com/17433503/88476652-b0550180-cf6c-11ea-8a0f-08835c760a26.png)
![issue2](https://user-images.githubusercontent.com/17433503/88476653-b34ff200-cf6c-11ea-89da-6b237722dc84.png)
Non-ASCII characters are doceded as ?.
Version in master branch seems to share the same issue and can be fixed in a same way.