### PR TITLE
Fix command rewards

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbquests/quest/reward/CommandReward.java
+++ b/src/main/java/com/feed_the_beast/ftbquests/quest/reward/CommandReward.java
@@ -104,7 +104,7 @@ public class CommandReward extends Reward
 		overrides.put("quest", quest);
 		overrides.put("team", FTBLibAPI.getTeam(player.getUniqueID()));
 
-		String s = command;
+		String s = command.startsWith("/") ? command.substring(1) : command;
 
 		for (Map.Entry<String, Object> entry : overrides.entrySet())
 		{


### PR DESCRIPTION
Fixes commands starting with a "/" not working on Magma