### PR TITLE
Fix LocationTask submission check

### DIFF
--- a/common/src/main/java/com/feed_the_beast/ftbquests/quest/task/LocationTask.java
+++ b/common/src/main/java/com/feed_the_beast/ftbquests/quest/task/LocationTask.java
@@ -152,7 +152,7 @@ public class LocationTask extends Task
 		{
 			if (task.ignoreDimension || task.dimension == player.level.dimension())
 			{
-				int y = Mth.floor(player.getX());
+				int y = Mth.floor(player.getY());
 
 				if (y >= task.y && y < task.y + task.h)
 				{


### PR DESCRIPTION
Get the player's Y coordinate instead of their X coordinate.

Fixes #541