### PR TITLE
Fix/workaround for syncing of quests when in a team

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/client/ClientQuestFile.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/client/ClientQuestFile.java
@@ -12,6 +12,7 @@ import dev.ftb.mods.ftbquests.quest.Quest;
 import dev.ftb.mods.ftbquests.quest.QuestFile;
 import dev.ftb.mods.ftbquests.quest.TeamData;
 import dev.ftb.mods.ftbquests.quest.theme.QuestTheme;
+import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import me.shedaniel.architectury.utils.Env;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.TextComponent;
@@ -43,7 +44,7 @@ public class ClientQuestFile extends QuestFile {
 		}
 
 		self = Objects.requireNonNull(getData(s));
-		self.name = Minecraft.getInstance().getUser().getName();
+		self.name = FTBTeamsAPI.getClientManager().getName(s).getString();
 		INSTANCE = this;
 
 		refreshGui();

--- a/common/src/main/java/dev/ftb/mods/ftbquests/quest/QuestFile.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/quest/QuestFile.java
@@ -1259,7 +1259,9 @@ public abstract class QuestFile extends QuestObject {
 	}
 
 	public void addData(TeamData data, boolean strong) {
-		teamDataMap.put(data.uuid, data);
+		if(!teamDataMap.containsKey(data.uuid)) {
+			teamDataMap.put(data.uuid, data);
+		}
 	}
 
 	public void refreshGui() {

--- a/common/src/main/java/dev/ftb/mods/ftbquests/quest/ServerQuestFile.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/quest/ServerQuestFile.java
@@ -12,6 +12,7 @@ import dev.ftb.mods.ftbquests.quest.task.TaskType;
 import dev.ftb.mods.ftbquests.quest.task.TaskTypes;
 import dev.ftb.mods.ftbquests.util.FTBQuestsInventoryListener;
 import dev.ftb.mods.ftbquests.util.FileUtils;
+import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import me.shedaniel.architectury.hooks.LevelResourceHooks;
 import me.shedaniel.architectury.platform.Platform;
 import me.shedaniel.architectury.utils.Env;
@@ -154,7 +155,7 @@ public class ServerQuestFile extends QuestFile {
 	}
 
 	public void onLoggedIn(ServerPlayer player) {
-		UUID id = player.getUUID();
+		UUID id = FTBTeamsAPI.getPlayerTeamID(player.getUUID());
 		TeamData data = teamDataMap.get(id);
 
 		if (data == null) {
@@ -163,7 +164,7 @@ public class ServerQuestFile extends QuestFile {
 		}
 
 		if (!data.name.equals(player.getGameProfile().getName())) {
-			data.name = player.getGameProfile().getName();
+			data.name = FTBTeamsAPI.getPlayerTeam(player).getDisplayName();
 			data.save();
 		}
 

--- a/common/src/main/java/dev/ftb/mods/ftbquests/util/FTBQuestsInventoryListener.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/util/FTBQuestsInventoryListener.java
@@ -6,6 +6,7 @@ import dev.ftb.mods.ftbquests.quest.Quest;
 import dev.ftb.mods.ftbquests.quest.ServerQuestFile;
 import dev.ftb.mods.ftbquests.quest.TeamData;
 import dev.ftb.mods.ftbquests.quest.task.Task;
+import dev.ftb.mods.ftbteams.FTBTeamsAPI;
 import me.shedaniel.architectury.hooks.PlayerHooks;
 import net.minecraft.core.NonNullList;
 import net.minecraft.server.level.ServerPlayer;
@@ -28,7 +29,7 @@ public class FTBQuestsInventoryListener implements ContainerListener {
 			return;
 		}
 
-		TeamData data = ServerQuestFile.INSTANCE.getNullablePlayerData(player.getUUID());
+		TeamData data = ServerQuestFile.INSTANCE.getNullablePlayerData(FTBTeamsAPI.getPlayerTeamID(player.getUUID()));
 
 		if (data == null || data.isLocked()) {
 			return;


### PR DESCRIPTION
When in a team, quest syncing was not working, for two reasons:
 * A mix of player and Team UUIDs was being used client-side, which prevented quest progress from being visible.
 * When another player in the team logs in, the local TeamData was overwritten by the other player's data.

Note that this patch does not fix the issue that a relog is required after joining a team. 