### PR TITLE
Fixed Panel from closing when mouse not over.

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/ChapterPanel.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/ChapterPanel.java
@@ -393,10 +393,6 @@ public class ChapterPanel extends Panel {
 	@Override
 	public void updateMouseOver(int mouseX, int mouseY) {
 		super.updateMouseOver(mouseX, mouseY);
-
-		if (expanded && !isMouseOver()) {
-			setExpanded(false);
-		}
 	}
 
 	@Override


### PR DESCRIPTION
Implements #566.

In other words, this prevents the panel from closing when the mouse is not over the ChapterPanel window. I don't know where the config file class is and there's no actual description to say how to properly build and compile so I just removed the section to show that (as far as I can see) this is where #566 is happening.