### PR TITLE
Add Scroll Bars for the Text Editor

### DIFF
--- a/src/main/java/com/feed_the_beast/ftbquests/texteditor/TextEditorFrame.java
+++ b/src/main/java/com/feed_the_beast/ftbquests/texteditor/TextEditorFrame.java
@@ -88,7 +88,12 @@ public class TextEditorFrame extends JFrame
 
 		panel.add(buttonPanel);
 
-		setContentPane(panel);
+		JScrollPane scrollablePanel = new JScrollPane(panel);
+		scrollablePanel.setVerticalScrollBarPolicy(JScrollPane.VERTICAL_SCROLLBAR_AS_NEEDED);
+		scrollablePanel.setHorizontalScrollBarPolicy(JScrollPane.HORIZONTAL_SCROLLBAR_AS_NEEDED);
+
+		setContentPane(scrollablePanel);
+
 		pack();
 		setLocationRelativeTo(null);
 		setVisible(true);


### PR DESCRIPTION
In the current version you cannot edit a very long quest with the text editor
This PR fixes it with both vertical and horizontal scroll bars
![キャプチャ1325](https://user-images.githubusercontent.com/39122497/166671945-803f4138-00c8-4417-bde8-cf5b3f5c7216.PNG)

