### PR TITLE
Fix a crash with the new version of KubeJS 6

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/FTBQuestsKubeJSEvents.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/FTBQuestsKubeJSEvents.java
@@ -2,12 +2,13 @@ package dev.ftb.mods.ftbquests.integration.kubejs;
 
 import dev.latvian.mods.kubejs.event.EventGroup;
 import dev.latvian.mods.kubejs.event.EventHandler;
+import dev.latvian.mods.kubejs.event.Extra;
 
 public interface FTBQuestsKubeJSEvents {
 	EventGroup EVENT_GROUP = EventGroup.of("FTBQuestsEvents");
 
-	EventHandler CUSTOM_TASK = EVENT_GROUP.server("customTask", () -> CustomTaskEventJS.class).supportsExtraId().cancelable();
-	EventHandler CUSTOM_REWARD = EVENT_GROUP.server("customReward", () -> CustomRewardEventJS.class).supportsExtraId().cancelable();
-	EventHandler OBJECT_COMPLETED = EVENT_GROUP.server("completed", () -> QuestObjectCompletedEventJS.class).supportsExtraId();
-	EventHandler OBJECT_STARTED = EVENT_GROUP.server("started", () -> QuestObjectStartedEventJS.class).supportsExtraId();
+	EventHandler CUSTOM_TASK = EVENT_GROUP.server("customTask", () -> CustomTaskEventJS.class).extra(Extra.STRING).cancelable();
+	EventHandler CUSTOM_REWARD = EVENT_GROUP.server("customReward", () -> CustomRewardEventJS.class).extra(Extra.STRING).cancelable();
+	EventHandler OBJECT_COMPLETED = EVENT_GROUP.server("completed", () -> QuestObjectCompletedEventJS.class).extra(Extra.STRING);
+	EventHandler OBJECT_STARTED = EVENT_GROUP.server("started", () -> QuestObjectStartedEventJS.class).extra(Extra.STRING);
 }

--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/KubeJSIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/KubeJSIntegration.java
@@ -32,17 +32,6 @@ public class KubeJSIntegration extends KubeJSPlugin {
 		});
 	}
 
-	//@SubscribeEvent
-	//public static void registerDocumentation(DocumentationEvent event)
-	//{
-	//	event.registerAttachedData(DataType.PLAYER, "ftbquests", FTBQuestsKubeJSPlayerData.class);
-	//
-	//	event.registerEvent("ftbquests.custom_task", CustomTaskEventJS.class).doubleParam("id").canCancel();
-	//	event.registerEvent("ftbquests.custom_reward", CustomRewardEventJS.class).doubleParam("id").canCancel();
-	//	event.registerEvent("ftbquests.completed", QuestObjectCompletedEventJS.class).doubleParam("id|tag");
-	//	event.registerEvent("ftbquests.started", TaskStartedEventJS.class).doubleParam("id|tag");
-	//}
-
 	@Override
 	public void registerBindings(BindingsEvent event) {
 		event.add("FTBQuests", FTBQuestsKubeJSWrapper.INSTANCE);

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -31,6 +31,6 @@
 		"itemfilters": ">=1902.2.9-build.46"
 	},
 	"breaks": {
-		"kubejs": "<1902.6.0-"
+		"kubejs": "<1902.6.0-build.107"
 	}
 }

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -50,7 +50,7 @@ side = "BOTH"
 [[dependencies.ftbquests]]
 modId = "kubejs"
 mandatory = false
-versionRange = "[1902.6.0-,)"
+versionRange = "[1902.6.0-build.107,)"
 ordering = "AFTER"
 side = "BOTH"
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ ftb_teams_version=1902.2.9-build.61
 itemfilters_version=1902.2.9-build.46
 # Optional deps
 rei_version=9.1.530
-kubejs_version=1902.6.0-build.66
+kubejs_version=1902.6.0-build.107
 gamestages_version=11.0.2
 bookshelf_version=16.1.4
 teamreborn_energy_version=2.2.0


### PR DESCRIPTION
Yet another event handler rework by Lat; these kinds of breaking changes should however, become a more rare occurrence as we near the actual *release* of KubeJS 6 ^^