### PR TITLE
fix: CF architectury slug is architectury-api now

### DIFF
--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -89,7 +89,7 @@ if (ENV.CURSEFORGE_KEY) {
 			addGameVersion "1.16.5"
 			mainArtifact(remapJar.archivePath)
 			relations {
-				requiredDependency 'architectury-forge'
+				requiredDependency 'architectury-api'
 				requiredDependency 'ftb-teams-forge'
 				requiredDependency 'ftb-library-forge'
 				requiredDependency 'item-filters-forge'


### PR DESCRIPTION
Bah!  bitten by the CF architectury slug ID change again