### PR TITLE
[1.16] fix: avoid crash if JEI hasn't provided runtime yet

### DIFF
--- a/forge/src/main/java/dev/ftb/mods/ftbquests/integration/jei/forge/FTBQuestsJEIHelperImpl.java
+++ b/forge/src/main/java/dev/ftb/mods/ftbquests/integration/jei/forge/FTBQuestsJEIHelperImpl.java
@@ -37,6 +37,8 @@ public class FTBQuestsJEIHelperImpl {
 	}
 
 	public static void showRecipes(Object object) {
+		if(FTBQuestsJEIIntegration.runtime == null)
+			return;
 		FTBQuestsJEIIntegration.runtime.getRecipesGui().show(FTBQuestsJEIIntegration.runtime.getRecipeManager().createFocus(IFocus.Mode.OUTPUT, object));
 	}
 }


### PR DESCRIPTION
If JEI hasn't loaded for some reason, it can cause a crash when a user clicks on a quest to see the recipe. (As an example, my performance mod ModernFix patches JEI to load asynchronously, and I am also working on getting this functionality into upstream JEI for 1.19.2/1.19.3.)

This PR fixes that by just doing nothing if the runtime is unavailable for whatever reason.