### PR TITLE
fix: fix compatiblity with kubejs 1902.6.1-build.242

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/FTBQuestsKubeJSEvents.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/FTBQuestsKubeJSEvents.java
@@ -7,8 +7,8 @@ import dev.latvian.mods.kubejs.event.Extra;
 public interface FTBQuestsKubeJSEvents {
 	EventGroup EVENT_GROUP = EventGroup.of("FTBQuestsEvents");
 
-	EventHandler CUSTOM_TASK = EVENT_GROUP.server("customTask", () -> CustomTaskEventJS.class).extra(Extra.STRING).cancelable();
-	EventHandler CUSTOM_REWARD = EVENT_GROUP.server("customReward", () -> CustomRewardEventJS.class).extra(Extra.STRING).cancelable();
+	EventHandler CUSTOM_TASK = EVENT_GROUP.server("customTask", () -> CustomTaskEventJS.class).extra(Extra.STRING).hasResult();
+	EventHandler CUSTOM_REWARD = EVENT_GROUP.server("customReward", () -> CustomRewardEventJS.class).extra(Extra.STRING).hasResult();
 	EventHandler OBJECT_COMPLETED = EVENT_GROUP.server("completed", () -> QuestObjectCompletedEventJS.class).extra(Extra.STRING);
 	EventHandler OBJECT_STARTED = EVENT_GROUP.server("started", () -> QuestObjectStartedEventJS.class).extra(Extra.STRING);
 }

--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/KubeJSIntegration.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/KubeJSIntegration.java
@@ -48,19 +48,11 @@ public class KubeJSIntegration extends KubeJSPlugin {
 	}
 
 	public static EventResult onCustomTask(CustomTaskEvent event) {
-		if (FTBQuestsKubeJSEvents.CUSTOM_TASK.post(event.getTask(), new CustomTaskEventJS(event))) {
-			return EventResult.interruptTrue();
-		}
-
-		return EventResult.pass();
+		return FTBQuestsKubeJSEvents.CUSTOM_TASK.post(ScriptType.SERVER, event.getTask(), new CustomTaskEventJS(event)).arch();
 	}
 
 	public static EventResult onCustomReward(CustomRewardEvent event) {
-		if (FTBQuestsKubeJSEvents.CUSTOM_REWARD.post(event.getReward(), new CustomRewardEventJS(event))) {
-			return EventResult.interruptTrue();
-		}
-
-		return EventResult.pass();
+		return FTBQuestsKubeJSEvents.CUSTOM_REWARD.post(ScriptType.SERVER, event.getReward(), new CustomRewardEventJS(event)).arch();
 	}
 
 	public static EventResult onCompleted(ObjectCompletedEvent<?> event) {
@@ -68,9 +60,9 @@ public class KubeJSIntegration extends KubeJSPlugin {
 			var kjsEvent = new QuestObjectCompletedEventJS(event);
 			var object = event.getObject();
 
-			FTBQuestsKubeJSEvents.OBJECT_COMPLETED.post(event.getObject(), kjsEvent);
+			FTBQuestsKubeJSEvents.OBJECT_COMPLETED.post(ScriptType.SERVER, event.getObject(), kjsEvent);
 			for (String tag : object.getTags()) {
-				FTBQuestsKubeJSEvents.OBJECT_COMPLETED.post('#' + tag, kjsEvent);
+				FTBQuestsKubeJSEvents.OBJECT_COMPLETED.post(ScriptType.SERVER, '#' + tag, kjsEvent);
 			}
 		}
 
@@ -82,9 +74,9 @@ public class KubeJSIntegration extends KubeJSPlugin {
 			var kjsEvent = new QuestObjectStartedEventJS(event);
 			var object = event.getObject();
 
-			FTBQuestsKubeJSEvents.OBJECT_STARTED.post(event.getObject(), kjsEvent);
+			FTBQuestsKubeJSEvents.OBJECT_STARTED.post(ScriptType.SERVER, event.getObject(), kjsEvent);
 			for (String tag : object.getTags()) {
-				FTBQuestsKubeJSEvents.OBJECT_STARTED.post('#' + tag, kjsEvent);
+				FTBQuestsKubeJSEvents.OBJECT_STARTED.post(ScriptType.SERVER, '#' + tag, kjsEvent);
 			}
 		}
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ ftb_teams_version=1902.2.9-build.61
 itemfilters_version=1902.2.9-build.46
 # Optional deps
 rei_version=9.1.530
-kubejs_version=1902.6.0-build.119
+kubejs_version=1902.6.1-build.242
 gamestages_version=11.0.2
 bookshelf_version=16.1.4
 teamreborn_energy_version=2.2.0


### PR DESCRIPTION
The kubejs 1902.6.1 introduced an API breaking change. This change updates FTB-Quests to use the new API.