### PR TITLE
feat: add keyboard shortcuts to copy and paste quests

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/QuestPanel.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/gui/quests/QuestPanel.java
@@ -513,7 +513,7 @@ public class QuestPanel extends Panel {
 		}).openGui();
 	}
 
-	private void copyAndCreateTask(Task task, double qx, double qy) {
+	public void copyAndCreateTask(Task task, double qx, double qy) {
 		Task task2 = TaskType.createTask(new Quest(questScreen.selectedChapter), task.getType().id.toString());
 		if (task2 != null) {
 			CompoundTag tag = new CompoundTag();

--- a/common/src/main/java/dev/ftb/mods/ftbquests/net/CopyQuestMessage.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/net/CopyQuestMessage.java
@@ -21,7 +21,7 @@ public class CopyQuestMessage extends BaseC2SMessage {
     private final long chapterId;
     private final double qx;
     private final double qy;
-    private final boolean copyDeps;
+    private boolean copyDeps;
 
     public CopyQuestMessage(Quest toCopy, Chapter chapter, double qx, double qy, boolean copyDeps) {
         id = toCopy.id;
@@ -37,6 +37,10 @@ public class CopyQuestMessage extends BaseC2SMessage {
         this.qx = buf.readDouble();
         this.qy = buf.readDouble();
         this.copyDeps = buf.readBoolean();
+    }
+
+    public void setCopyDeps(boolean newCopyDeps) {
+        this.copyDeps = newCopyDeps;
     }
 
     @Override

--- a/common/src/main/resources/assets/ftbquests/lang/en_us.json
+++ b/common/src/main/resources/assets/ftbquests/lang/en_us.json
@@ -145,6 +145,8 @@
 	"ftbquests.quest": "Quest",
 	"ftbquests.quests": "Quests",
 	"ftbquests.quest.completed": "Quest completed!",
+	"ftbquests.quest.copied": "Copied quest:",
+	"ftbquests.quest.cannot_copy_many": "Copying many quests is not implemented!",
 	"ftbquests.quest.subtitle": "Subtitle",
 	"ftbquests.quest.description": "Description",
 	"ftbquests.quest.x": "X",


### PR DESCRIPTION
Ctrl + C copies the selected quest and a toast is displayed with the quest title Ctrl + V pastes the quest Ctrl + Shift + V pastes without dependencies
Ctrl + Alt + V pastes the quest link

Notes for things to tackle in separate PRs:

1. when doing Ctrl + C with multiple quests selected an error toast is displayed

fixes https://github.com/FTBTeam/FTB-Mods-Issues/issues/973