### PR TITLE
1.18/dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1802.3.16]
+
+### Fixed
+* Work around a hard-to-reproduce crash with JEI not being initialised when clicking items to show recipes
+
 ## [1802.3.15]
 
 ### Added

--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/QuestObjectCompletedEventJS.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/QuestObjectCompletedEventJS.java
@@ -1,5 +1,6 @@
 package dev.ftb.mods.ftbquests.integration.kubejs;
 
+import dev.ftb.mods.ftbquests.FTBQuests;
 import dev.ftb.mods.ftbquests.events.ObjectCompletedEvent;
 import dev.ftb.mods.ftbquests.quest.QuestObject;
 import dev.ftb.mods.ftbquests.quest.ServerQuestFile;
@@ -8,6 +9,7 @@ import dev.latvian.mods.kubejs.player.EntityArrayList;
 import dev.latvian.mods.kubejs.player.ServerPlayerJS;
 import dev.latvian.mods.kubejs.server.ServerEventJS;
 import dev.latvian.mods.kubejs.server.ServerJS;
+import net.fabricmc.loader.impl.util.ExceptionUtil;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -45,10 +47,19 @@ public class QuestObjectCompletedEventJS extends ServerEventJS {
 
 	@Nullable
 	public ServerPlayerJS getPlayer() {
-		if (!(event.getData().file instanceof ServerQuestFile)) {
+		if (!(event.getData().file instanceof ServerQuestFile sqf)) {
 			return null;
 		}
 
-		return ServerJS.instance.getPlayer(PlayerSelector.mc(((ServerQuestFile) event.getData().file).getCurrentPlayer()));
+		if (sqf.getCurrentPlayer() == null) {
+			FTBQuests.LOGGER.error("player is unexpectedly null in server quest file!");
+			try {
+				throw new Exception();
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+
+		return ServerJS.instance.getPlayer(PlayerSelector.mc(sqf.getCurrentPlayer()));
 	}
 }

--- a/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/QuestObjectCompletedEventJS.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/integration/kubejs/QuestObjectCompletedEventJS.java
@@ -10,6 +10,7 @@ import dev.latvian.mods.kubejs.player.ServerPlayerJS;
 import dev.latvian.mods.kubejs.server.ServerEventJS;
 import dev.latvian.mods.kubejs.server.ServerJS;
 import net.fabricmc.loader.impl.util.ExceptionUtil;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.jetbrains.annotations.Nullable;
 
 /**
@@ -56,7 +57,7 @@ public class QuestObjectCompletedEventJS extends ServerEventJS {
 			try {
 				throw new Exception();
 			} catch (Exception e) {
-				e.printStackTrace();
+				FTBQuests.LOGGER.error(ExceptionUtils.getStackTrace(e));
 			}
 		}
 

--- a/forge/src/main/java/dev/ftb/mods/ftbquests/integration/forge/FTBQuestsJEIHelperImpl.java
+++ b/forge/src/main/java/dev/ftb/mods/ftbquests/integration/forge/FTBQuestsJEIHelperImpl.java
@@ -5,6 +5,7 @@ import dev.ftb.mods.ftbquests.integration.jei.LootCrateRecipeManagerPlugin;
 import dev.ftb.mods.ftbquests.integration.jei.QuestRecipeManagerPlugin;
 import dev.ftb.mods.ftbquests.quest.QuestObjectBase;
 import mezz.jei.api.recipe.IFocus;
+import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraftforge.fml.ModList;
 
 import static dev.ftb.mods.ftbquests.integration.FTBQuestsJEIHelper.LOOTCRATES;
@@ -37,6 +38,9 @@ public class FTBQuestsJEIHelperImpl {
 	}
 
 	public static void showRecipes(Object object) {
-		FTBQuestsJEIIntegration.runtime.getRecipesGui().show(FTBQuestsJEIIntegration.runtime.getRecipeManager().createFocus(IFocus.Mode.OUTPUT, object));
+		IJeiRuntime runtime = FTBQuestsJEIIntegration.runtime;
+		if (runtime != null) {
+			runtime.getRecipesGui().show(runtime.getRecipeManager().createFocus(IFocus.Mode.OUTPUT, object));
+		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ archives_base_name=ftb-quests
 minecraft_version=1.18.2
 
 # Build time
-mod_version=1802.3.15
+mod_version=1802.3.16
 maven_group=dev.ftb.mods
 mod_author=FTB Team
 


### PR DESCRIPTION
Fix a crash caused by JEI runtime not being available (related to using REI, maybe?)

Also "temp" debugging code can stay in, since it provides more info if anything goes wrong there...