### PR TITLE
fix: check for null source in playerKill handler to prevent NPE

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbquests/FTBQuestsEventHandler.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/FTBQuestsEventHandler.java
@@ -114,7 +114,7 @@ public enum FTBQuestsEventHandler {
 	}
 
 	private EventResult playerKill(LivingEntity entity, DamageSource source) {
-		if (source.getEntity() instanceof ServerPlayer player && !PlayerHooks.isFake(player)) {
+		if (source != null && source.getEntity() instanceof ServerPlayer player && !PlayerHooks.isFake(player)) {
 			if (killTasks == null) {
 				killTasks = ServerQuestFile.INSTANCE.collect(KillTask.class);
 			}

--- a/common/src/main/java/dev/ftb/mods/ftbquests/FTBQuestsEventHandler.java
+++ b/common/src/main/java/dev/ftb/mods/ftbquests/FTBQuestsEventHandler.java
@@ -114,7 +114,12 @@ public enum FTBQuestsEventHandler {
 	}
 
 	private EventResult playerKill(LivingEntity entity, DamageSource source) {
-		if (source != null && source.getEntity() instanceof ServerPlayer player && !PlayerHooks.isFake(player)) {
+		// `source` should never be null, this is a defensive check against badly behaved mods.
+		if (source == null) {
+			return EventResult.pass();
+		}
+
+		if (source.getEntity() instanceof ServerPlayer player && !PlayerHooks.isFake(player)) {
 			if (killTasks == null) {
 				killTasks = ServerQuestFile.INSTANCE.collect(KillTask.class);
 			}


### PR DESCRIPTION
im not certain what the nullability contract of the event's source is supposed to be, but i am certain that NPEs are being hit here.
here's one log from a Craftoria 1.17.3 server https://mclo.gs/jv1f0nF
theres quite a few more reports in the AOE Studios discord server.